### PR TITLE
Ensure docker images use native Python installation

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -25,7 +25,6 @@ http_archive(
     url="https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
 )
 
-
 # Install skylib
 http_archive(
     name="bazel_skylib",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -17,7 +17,7 @@ environment(
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Python rules:
+# Fetch Python rules:
 http_archive(
     name="rules_python",
     sha256="9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
@@ -26,8 +26,42 @@ http_archive(
 )
 
 
-# Install Python:
+# Install skylib
+http_archive(
+    name="bazel_skylib",
+    urls=[
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+    ],
+    sha256="af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
+)
+
+
+# Fetch Docker rules:
+http_archive(
+    name="io_bazel_rules_docker",
+    sha256="b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls=["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+)
+
+load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories="repositories")
+container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps="deps")
+container_deps(go_repository_default_config="@//:WORKSPACE.bazel")
+
+
+load("//tools/packaging/docker:repositories.bzl", local_container_repositories="repositories")
+local_container_repositories()
+
+
+# Register Python toolchain and repositories
+
+# This must happen after `local_container_repositories` above, to ensure the correct Python
+# toolchain is used for Docker images). Otherwise Python itself will be loaded as the final
+# layer in the image. See https://github.com/bazelbuild/rules_docker/issues/1858
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
 python_register_toolchains(
     name="python",
     # Available versions are listed in @rules_python//python:versions.bzl.
@@ -49,32 +83,3 @@ pipenv_parse(
 # Create repos for each dependency in python_deps
 load("@python_deps//:requirements.bzl", "install_deps")
 install_deps()
-
-
-# Install skylib
-http_archive(
-    name="bazel_skylib",
-    urls=[
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
-    ],
-    sha256="af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
-)
-
-
-# Docker rules:
-http_archive(
-    name="io_bazel_rules_docker",
-    sha256="b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls=["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
-)
-
-load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories="repositories")
-container_repositories()
-
-load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps="deps")
-container_deps(go_repository_default_config="@//:WORKSPACE.bazel")
-
-
-load("//tools/packaging/docker:repositories.bzl", local_container_repositories="repositories")
-local_container_repositories()

--- a/tools/packaging/docker/BUILD.bazel
+++ b/tools/packaging/docker/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("//tools/packaging/docker:repositories.bzl", "image")
 
@@ -11,4 +12,32 @@ container_image(
     },
     workdir="/app",
     visibility=["//visibility:public"],
+)
+
+
+# Python container toolchain:
+py_runtime(
+    name="container_python_runtime",
+    interpreter_path="/usr/local/bin/python",  # Path for python:3.10.2-slim
+    python_version="PY3",
+)
+py_runtime_pair(
+    name="container_python_runtime_pair",
+    py2_runtime=None,
+    py3_runtime="container_python_runtime",
+)
+toolchain(
+    name="container_python_toolchain",
+    exec_compatible_with=["@io_bazel_rules_docker//platforms:run_in_container"],
+    toolchain=":container_python_runtime_pair",
+    toolchain_type="@bazel_tools//tools/python:toolchain_type",
+)
+
+
+# C++ container toolchain (required during build for some reason)
+toolchain(
+    name="container_cc_toolchain",
+    exec_compatible_with=["@io_bazel_rules_docker//platforms:run_in_container"],
+    toolchain="@local_config_cc//:cc-compiler-k8",
+    toolchain_type="@bazel_tools//tools/cpp:toolchain_type",
 )

--- a/tools/packaging/docker/repositories.bzl
+++ b/tools/packaging/docker/repositories.bzl
@@ -25,6 +25,6 @@ def repositories():
     native.register_toolchains("//tools/packaging/docker:container_python_toolchain")
     native.register_toolchains("//tools/packaging/docker:container_cc_toolchain")
     native.register_execution_platforms(
-        "@io_bazel_rules_docker//platforms:local_container_platform",
         "@local_config_platform//:host",
+        "@io_bazel_rules_docker//platforms:local_container_platform",
     )

--- a/tools/packaging/docker/repositories.bzl
+++ b/tools/packaging/docker/repositories.bzl
@@ -21,3 +21,10 @@ def repositories():
             name=name,
             **image,
         )
+
+    native.register_toolchains("//tools/packaging/docker:container_python_toolchain")
+    native.register_toolchains("//tools/packaging/docker:container_cc_toolchain")
+    native.register_execution_platforms(
+        "@local_config_platform//:host",
+        "@io_bazel_rules_docker//platforms:local_container_platform",
+    )

--- a/tools/packaging/docker/repositories.bzl
+++ b/tools/packaging/docker/repositories.bzl
@@ -25,6 +25,6 @@ def repositories():
     native.register_toolchains("//tools/packaging/docker:container_python_toolchain")
     native.register_toolchains("//tools/packaging/docker:container_cc_toolchain")
     native.register_execution_platforms(
-        "@local_config_platform//:host",
         "@io_bazel_rules_docker//platforms:local_container_platform",
+        "@local_config_platform//:host",
     )

--- a/tools/packaging/docker/rules.bzl
+++ b/tools/packaging/docker/rules.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_docker//lang:image.bzl", "app_layer")
+load("@io_bazel_rules_docker//lang:image.bzl", "app_layer", "filter_layer")
 load("@io_bazel_rules_docker//container:push.bzl", "container_push")
 load("@secrets//:vars.bzl", "IMAGE_REGISTRY")
 
@@ -18,7 +18,12 @@ def python_image(
         name=binary_name,
         **kwargs,
     )
-    for idx, dep in enumerate(kwargs.get("deps", [])):
+
+    external_deps_layer = "{}.layer.external".format(name)
+    filter_layer(name=external_deps_layer, dep=binary_name, filter="@")
+
+    deps = [external_deps_layer] + kwargs.get("deps", [])
+    for idx, dep in enumerate(deps):
         base = app_layer(
             name="{}.layer.{}".format(name, idx),
             base=base,

--- a/tools/packaging/docker/rules.bzl
+++ b/tools/packaging/docker/rules.bzl
@@ -18,40 +18,30 @@ def python_image(
         name=binary_name,
         **kwargs,
     )
-    # TODO: I think Python itself is getting loaded in the final layer, which may
-    # explain why the final layer is 250MB :(
-    # There isn't actually any need to vendor python at all, its already in the image.
     for idx, dep in enumerate(kwargs.get("deps", [])):
-        if idx == (len(kwargs.get("deps", [])) - 1):
-            base = app_layer(
-                name=name,
-                base=base,
-                dep=dep,
-                entrypoint=entrypoint or ["/usr/local/bin/python"],
-                visibility=visibility,
-                tags=tags,
-                args=kwargs.get("args"),
-                data=kwargs.get("data"),
-                create_empty_workspace_dir=True,
-            )
-        else:
-            base = app_layer(
-                name="{}.layer.{}".format(name, idx),
-                base=base,
-                dep=dep,
-            )
+        base = app_layer(
+            name="{}.layer.{}".format(name, idx),
+            base=base,
+            dep=dep,
+        )
+        base = app_layer(
+            name="{}.layer.{}-symlinks".format(name, idx),
+            base=base,
+            dep=dep,
+            binary=binary_name,
+        )
 
-    # app_layer(
-    #     name=name,
-    #     base=base,
-    #     entrypoint=entrypoint or ["/usr/local/bin/python"],
-    #     binary=binary_name,
-    #     visibility=visibility,
-    #     tags=tags,
-    #     args=kwargs.get("args"),
-    #     data=kwargs.get("data"),
-    #     create_empty_workspace_dir=True,
-    # )
+    app_layer(
+        name=name,
+        base=base,
+        entrypoint=entrypoint or ["/usr/local/bin/python"],
+        binary=binary_name,
+        visibility=visibility,
+        tags=tags,
+        args=kwargs.get("args"),
+        data=kwargs.get("data"),
+        create_empty_workspace_dir=True,
+    )
 
     # TODO: It would be cool to automatically generate the repository name from the target path.
     # E.g. //src/domain/target:image would go in {registry}/{workspace_name}/domain/target

--- a/tools/packaging/docker/rules.bzl
+++ b/tools/packaging/docker/rules.bzl
@@ -22,22 +22,36 @@ def python_image(
     # explain why the final layer is 250MB :(
     # There isn't actually any need to vendor python at all, its already in the image.
     for idx, dep in enumerate(kwargs.get("deps", [])):
-        base = app_layer(
-            name="{}.layer.{}".format(name, idx),
-            base=base,
-            dep=dep,
-        )
-    app_layer(
-        name=name,
-        base=base,
-        entrypoint=entrypoint or ["/usr/local/bin/python"],
-        binary=binary_name,
-        visibility=visibility,
-        tags=tags,
-        args=kwargs.get("args"),
-        data=kwargs.get("data"),
-        create_empty_workspace_dir=True,
-    )
+        if idx == (len(kwargs.get("deps", [])) - 1):
+            base = app_layer(
+                name=name,
+                base=base,
+                dep=dep,
+                entrypoint=entrypoint or ["/usr/local/bin/python"],
+                visibility=visibility,
+                tags=tags,
+                args=kwargs.get("args"),
+                data=kwargs.get("data"),
+                create_empty_workspace_dir=True,
+            )
+        else:
+            base = app_layer(
+                name="{}.layer.{}".format(name, idx),
+                base=base,
+                dep=dep,
+            )
+
+    # app_layer(
+    #     name=name,
+    #     base=base,
+    #     entrypoint=entrypoint or ["/usr/local/bin/python"],
+    #     binary=binary_name,
+    #     visibility=visibility,
+    #     tags=tags,
+    #     args=kwargs.get("args"),
+    #     data=kwargs.get("data"),
+    #     create_empty_workspace_dir=True,
+    # )
 
     # TODO: It would be cool to automatically generate the repository name from the target path.
     # E.g. //src/domain/target:image would go in {registry}/{workspace_name}/domain/target

--- a/tools/packaging/docker/rules.bzl
+++ b/tools/packaging/docker/rules.bzl
@@ -16,6 +16,7 @@ def python_image(
     base = base or "//tools/packaging/docker:default_python_base"
     native.py_binary(
         name=binary_name,
+        exec_compatible_with=["@io_bazel_rules_docker//platforms:run_in_container"],
         **kwargs,
     )
 


### PR DESCRIPTION
This PR modifies how Python docker images are built, so that the existing Python installation is used. Previously, the full Python installation was copied to the image in the final layer, which is incredibly sub-optimal.

Relates to #4